### PR TITLE
fix: SEO audit — 7 issues across sitemap, structured data, and headers

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -774,6 +774,18 @@ func SitemapHandler(c echo.Context) error {
 		}
 	}
 
+	guidePosts, err := loadAllGuidePosts()
+	if err == nil {
+		for _, post := range guidePosts {
+			sitemap += fmt.Sprintf(`
+  <url>
+    <loc>%s/guides/%s</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>`, baseURL, post.IssueSlug)
+		}
+	}
+
 	sitemap += `
 </urlset>`
 

--- a/views/header.templ
+++ b/views/header.templ
@@ -35,8 +35,8 @@ templ Header() {
         <link rel="icon" href="/favicon.ico" sizes="any">
         <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/favicon/light/apple-touch-icon.png">
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="/static/tailwind.css?v=202508134" rel="stylesheet">
-        <link href="/static/styles.css?v=202508134" rel="stylesheet">
+        <link href="/static/tailwind.css?v=20250814" rel="stylesheet">
+        <link href="/static/styles.css?v=20250814" rel="stylesheet">
         <script src="/static/htmx.min.js"></script>
 
         <meta property="og:title" content="CypherGoat - Swap Crypto at the Best Rate on the Market">
@@ -496,8 +496,8 @@ templ IndexHeader() {
         <link rel="icon" href="/favicon.ico" sizes="any">
         <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/favicon/light/apple-touch-icon.png">
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="/static/tailwind.css?v=202508134" rel="stylesheet">
-        <link href="/static/styles.css?v=202508134" rel="stylesheet">
+        <link href="/static/tailwind.css?v=20250814" rel="stylesheet">
+        <link href="/static/styles.css?v=20250814" rel="stylesheet">
         <script src="/static/htmx.min.js"></script>
         <link rel="canonical" href="https://cyphergoat.com">
 
@@ -741,7 +741,7 @@ templ IndexHeader() {
       "name": "What cryptocurrencies are supported?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "We currently support 60+ coins and 15+ exchanges, covering all major cryptocurrencies and many altcoins."
+        "text": "We currently support 60+ coins and 20+ exchanges, covering all major cryptocurrencies and many altcoins."
       }
     },
     {
@@ -768,12 +768,16 @@ templ IndexHeader() {
 }
 
 func generateBlogPostJsonLD(post *BlogPostData) string {
+    pageURL := fmt.Sprintf("https://cyphergoat.com/blog/%s", post.Slug)
+    if post.IssueSlug != "" {
+        pageURL = fmt.Sprintf("https://cyphergoat.com/this-week-in-monero/%s", post.IssueSlug)
+    }
+
     jsonLD := map[string]interface{}{
         "@context": "https://schema.org",
         "@type": "BlogPosting",
         "headline": post.Title,
         "description": post.Description,
-        "image": post.Image,
         "author": map[string]interface{}{
             "@type": "Person",
             "name": post.Author,
@@ -789,15 +793,19 @@ func generateBlogPostJsonLD(post *BlogPostData) string {
         "datePublished": post.Date,
         "mainEntityOfPage": map[string]interface{}{
             "@type": "WebPage",
-            "@id": fmt.Sprintf("https://cyphergoat.com/blog/%s", post.Slug),
+            "@id": pageURL,
         },
     }
-    
+
+    if post.Image != "" {
+        jsonLD["image"] = post.Image
+    }
+
     jsonBytes, err := json.MarshalIndent(jsonLD, "", "  ")
     if err != nil {
         return "<script type=\"application/ld+json\">{}</script>"
     }
-    
+
     return "<script type=\"application/ld+json\">\n" + string(jsonBytes) + "\n</script>"
 }
 
@@ -815,10 +823,10 @@ templ BlogHeader(post *BlogPostData) {
         <link rel="icon" href="/favicon.ico" sizes="any">
         <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/favicon/light/apple-touch-icon.png">
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="/static/tailwind.css?v=202508134" rel="stylesheet">
-        <link href="/static/styles.css?v=202508134" rel="stylesheet">
+        <link href="/static/tailwind.css?v=20250814" rel="stylesheet">
+        <link href="/static/styles.css?v=20250814" rel="stylesheet">
         <script src="/static/htmx.min.js"></script>
-        
+
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
         <title>{ post.Title } | CypherGoat</title>
@@ -1052,6 +1060,12 @@ templ GuidesIndexHeader() {
         <meta charset="UTF-8" />
         <link rel="icon" type="image/x-icon" href="/static/icons/favicon/light/favicon.ico" media="(prefers-color-scheme: light)">
         <link rel="icon" type="image/x-icon" href="/static/icons/favicon/dark/favicon.ico" media="(prefers-color-scheme: dark)">
+        <link rel="icon" type="image/png" sizes="32x32" href="/static/icons/favicon/light/favicon-32x32.png" media="(prefers-color-scheme: light)">
+        <link rel="icon" type="image/png" sizes="32x32" href="/static/icons/favicon/dark/favicon-32x32.png" media="(prefers-color-scheme: dark)">
+        <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/favicon/light/favicon-16x16.png" media="(prefers-color-scheme: light)">
+        <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/favicon/dark/favicon-16x16.png" media="(prefers-color-scheme: dark)">
+        <link rel="icon" href="/favicon.ico" sizes="any">
+        <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/favicon/light/apple-touch-icon.png">
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link href="/static/tailwind.css?v=20250814" rel="stylesheet">
         <link href="/static/styles.css?v=20250814" rel="stylesheet">
@@ -1082,6 +1096,35 @@ templ GuidesIndexHeader() {
         <meta name="twitter:image:alt" content="CypherGoat Guides">
 
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+<script defer data-domain="cyphergoat.com" src="https://stats.cyphergoat.com/js/script.outbound-links.tagged-events.js"></script>
+<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                const menuToggle = document.getElementById("menu-toggle");
+                const navMenu = document.getElementById("nav-menu");
+
+                menuToggle.addEventListener("click", function () {
+                    navMenu.classList.toggle("nav-active");
+                });
+
+                document.addEventListener("click", function (e) {
+                    if (!navMenu.contains(e.target) && !menuToggle.contains(e.target) && navMenu.classList.contains("nav-active")) {
+                        navMenu.classList.remove("nav-active");
+                    }
+                });
+
+                const menuLinks = navMenu.querySelectorAll("a");
+                menuLinks.forEach(link => {
+                    link.addEventListener("click", function() {
+                        if (window.innerWidth < 1024) {
+                            navMenu.classList.remove("nav-active");
+                        }
+                    });
+                });
+            });
+        </script>
     </head>
     <body class="bg-[#121520]">
     <header class="flex flex-wrap items-center w-full text-sm py-1 shadow-md relative" style="background: linear-gradient(145deg, #1a1f2e, #222633); border-bottom: 1px solid rgba(255, 255, 255, 0.05);">
@@ -1116,9 +1159,15 @@ templ GuidesPostHeader(post *BlogPostData) {
         <meta charset="UTF-8" />
         <link rel="icon" type="image/x-icon" href="/static/icons/favicon/light/favicon.ico" media="(prefers-color-scheme: light)">
         <link rel="icon" type="image/x-icon" href="/static/icons/favicon/dark/favicon.ico" media="(prefers-color-scheme: dark)">
+        <link rel="icon" type="image/png" sizes="32x32" href="/static/icons/favicon/light/favicon-32x32.png" media="(prefers-color-scheme: light)">
+        <link rel="icon" type="image/png" sizes="32x32" href="/static/icons/favicon/dark/favicon-32x32.png" media="(prefers-color-scheme: dark)">
+        <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/favicon/light/favicon-16x16.png" media="(prefers-color-scheme: light)">
+        <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/favicon/dark/favicon-16x16.png" media="(prefers-color-scheme: dark)">
+        <link rel="icon" href="/favicon.ico" sizes="any">
+        <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/favicon/light/apple-touch-icon.png">
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link href="/static/tailwind.css?v=202508134" rel="stylesheet">
-        <link href="/static/styles.css?v=202508134" rel="stylesheet">
+        <link href="/static/tailwind.css?v=20250814" rel="stylesheet">
+        <link href="/static/styles.css?v=20250814" rel="stylesheet">
         <script src="/static/htmx.min.js"></script>
 
         <title>{ post.Title } | CypherGoat Guides</title>
@@ -1196,7 +1245,6 @@ func generateGuidesPostJsonLD(post *BlogPostData) string {
         "@type": "Article",
         "headline": post.Title,
         "description": post.Description,
-        "image": post.Image,
         "author": map[string]interface{}{
             "@type": "Person",
             "name": post.Author,
@@ -1214,6 +1262,10 @@ func generateGuidesPostJsonLD(post *BlogPostData) string {
             "@type": "WebPage",
             "@id": fmt.Sprintf("https://cyphergoat.com/guides/%s", post.IssueSlug),
         },
+    }
+
+    if post.Image != "" {
+        jsonLD["image"] = post.Image
     }
 
     jsonBytes, err := json.MarshalIndent(jsonLD, "", "  ")


### PR DESCRIPTION
- Fix CSS cache-busting version typo (202508134 → 20250814) in
  Header(), IndexHeader(), BlogHeader(), GuidesPostHeader()
- Add /guides/{slug} URLs to sitemap (guide posts were entirely missing)
- Fix FAQ schema: "15+ exchanges" → "20+" to match all other copy
- Fix generateBlogPostJsonLD: omit image field when empty (invalid JSON-LD);
  use correct TWIM URL in mainEntityOfPage for TWIM posts
- Fix generateGuidesPostJsonLD: omit image field when empty
- Fix GuidesIndexHeader: add missing 32x32/16x16 favicon PNGs,
  fallback favicon.ico, apple-touch-icon, Plausible analytics script,
  and mobile nav toggle JavaScript (menu was broken on mobile)
- Fix GuidesPostHeader: add missing 32x32/16x16 favicon PNGs,
  fallback favicon.ico, and apple-touch-icon